### PR TITLE
Feature/persist subscription status to file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,7 +1048,7 @@
       "dev": true
     },
     "common-display-module": {
-      "version": "git://github.com/Rise-Vision/common-display-module.git#3de6703323e9f4a585d1d8b10ed9886687cc489a",
+      "version": "git://github.com/Rise-Vision/common-display-module.git#4e31eeaddc172328226217a609360041ca58bd4c",
       "requires": {
         "https-proxy-agent": "2.1.1",
         "node-ipc": "9.1.1",
@@ -1072,6 +1072,28 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "fs-extra": {
+          "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
+          "requires": {
+            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
+              "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
         },
         "rise-common-electron": {
           "version": "git://github.com/Rise-Vision/rise-common-electron.git#5c8c0c38311dd9c79807e1cb57e70463c7ebeb46",
@@ -1099,6 +1121,9 @@
               }
             }
           }
+        },
+        "windows-shortcuts": {
+          "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "zip-webpack-plugin": "^2.0.0"
   },
   "dependencies": {
-    "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v2.5.0",
+    "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v3.0.0",
     "rise-common-electron": "git+https://github.com/Rise-Vision/rise-common-electron.git#v2.2.5"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -8,8 +8,8 @@ const moduleName = "licensing";
 
 const CACHE_FILE_NAME = "licensing-cache.json";
 const SUBSCRIPTION_API_SERVER = 'store-dot-rvaserver2.appspot.com';
-const PRODUCT_CODES = [
-  licensing.RISE_PLAYER_PROFESSIONAL_PRODUCT_CODE,
+
+const PRODUCT_CODES_BY_COMPANY = [
   licensing.RISE_STORAGE_PRODUCT_CODE,
 ].join(',');
 
@@ -20,7 +20,16 @@ function getSubscriptionStatusApiUrl() {
     throw Error("Company ID not set");
   }
 
-  return `https://${SUBSCRIPTION_API_SERVER}/v1/company/${companyId}/product/status?pc=${PRODUCT_CODES}`;
+  return `https://${SUBSCRIPTION_API_SERVER}/v1/company/${companyId}/product/status?pc=${
+    PRODUCT_CODES_BY_COMPANY
+  }`;
+}
+
+// this call is deprectated and will be substituted by Apps Display Licensing when it becomes available.
+function getRisePlayerProfessionalAuthorizationApiUrl(displayId) {
+  return `https://${SUBSCRIPTION_API_SERVER}/v1/widget/auth?id=${displayId}&pc=${
+    licensing.RISE_PLAYER_PROFESSIONAL_PRODUCT_CODE
+  }`;
 }
 
 function getCachePath() {
@@ -50,5 +59,6 @@ module.exports = {
     companyId = id;
   },
   getCachePath,
-  getSubscriptionStatusApiUrl
+  getSubscriptionStatusApiUrl,
+  getRisePlayerProfessionalAuthorizationApiUrl
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,16 @@
 /* eslint-disable array-bracket-newline, line-comment-position, no-inline-comments, comma-dangle */
 
 const common = require("common-display-module");
+const licensing = require("common-display-module/licensing");
+const path = require("path");
 
 const moduleName = "licensing";
+
+const CACHE_FILE_NAME = "licensing-cache.json";
 const SUBSCRIPTION_API_SERVER = 'store-dot-rvaserver2.appspot.com';
 const PRODUCT_CODES = [
-  'c4b368be86245bf9501baaa6e0b00df9719869fd', // Rise Player Professional
-  'b0cba08a4baa0c62b8cdc621b6f6a124f89a03db', // Rise Storage
+  licensing.RISE_PLAYER_PROFESSIONAL_PRODUCT_CODE,
+  licensing.RISE_STORAGE_PRODUCT_CODE,
 ].join(',');
 
 let companyId = null;
@@ -17,6 +21,16 @@ function getSubscriptionStatusApiUrl() {
   }
 
   return `https://${SUBSCRIPTION_API_SERVER}/v1/company/${companyId}/product/status?pc=${PRODUCT_CODES}`;
+}
+
+function getCachePath() {
+  const modulePath = common.getModulePath(moduleName);
+
+  if (!modulePath) {
+    throw new Error(`No path found for ${moduleName}`);
+  }
+
+  return path.join(modulePath, CACHE_FILE_NAME);
 }
 
 module.exports = {
@@ -35,5 +49,6 @@ module.exports = {
   setCompanyId(id) {
     companyId = id;
   },
+  getCachePath,
   getSubscriptionStatusApiUrl
 };

--- a/src/deprecated_widget_api_iterations.js
+++ b/src/deprecated_widget_api_iterations.js
@@ -4,6 +4,7 @@
 // This will disappear as soon as Apps Display Licensing is available so code was copied from iterations.js with no special effort to refactor common functionality.
 
 const logger = require("./logger");
+const persistence = require("./persistence");
 const subscriptions = require("./subscriptions");
 
 const MINUTES = 60 * 1000;
@@ -18,6 +19,7 @@ function ensureLicensingLoopIsRunning(schedule = setInterval) {
   if (!timerId) {
     return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
     .then(() => programLicensingDataUpdate(schedule, EACH_DAY))
+    .then(persistence.saveAndReport)
     .catch(error =>
       logger.logDeprecatedWidgetAPICallError(error, true)
       .then(() => programLicensingDataLoadingRetries(schedule))
@@ -32,6 +34,7 @@ function programLicensingDataUpdate(schedule, interval) {
 
   timerId = schedule(() => {
     return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
+    .then(persistence.saveAndReport)
     .catch(logger.logDeprecatedWidgetAPICallError);
   }, interval);
 }
@@ -57,6 +60,7 @@ function retryLicensingDataLoad(schedule) {
     // switch to normal reporting
     programLicensingDataUpdate(schedule, EACH_DAY)
   })
+  .then(persistence.saveAndReport)
   .catch(error => {
     retryCounts += 1;
 

--- a/src/deprecated_widget_api_iterations.js
+++ b/src/deprecated_widget_api_iterations.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-magic-numbers, line-comment-position, no-inline-comments, function-paren-newline */
+
+// Iteration loop for deprecated widget API.
+// This will disappear as soon as Apps Display Licensing is available so code was copied from iterations.js with no special effort to refactor common functionality.
+
+const logger = require("./logger");
+const subscriptions = require("./subscriptions");
+
+const MINUTES = 60 * 1000;
+const EACH_5_MINUTES = 5 * MINUTES;
+const EACH_HOUR = 60 * MINUTES;
+const EACH_DAY = 24 * EACH_HOUR;
+
+let timerId = null;
+let retryCounts = 0;
+
+function ensureLicensingLoopIsRunning(schedule = setInterval) {
+  if (!timerId) {
+    return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
+    .then(() => programLicensingDataUpdate(schedule, EACH_DAY))
+    .catch(error =>
+      logger.logDeprecatedWidgetAPICallError(error, true)
+      .then(() => programLicensingDataLoadingRetries(schedule))
+    );
+  }
+
+  return Promise.resolve();
+}
+
+function programLicensingDataUpdate(schedule, interval) {
+  stop();
+
+  timerId = schedule(() => {
+    return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
+    .catch(logger.logDeprecatedWidgetAPICallError);
+  }, interval);
+}
+
+function programLicensingDataLoadingRetries(schedule) {
+  timerId = schedule(() => {
+    if (retryCounts > 10) {
+      // stop and reprogram every hour
+      stop();
+
+      timerId = schedule(() => retryLicensingDataLoad(schedule), EACH_HOUR);
+    } else {
+      return retryLicensingDataLoad(schedule);
+    }
+  }, EACH_5_MINUTES);
+}
+
+function retryLicensingDataLoad(schedule) {
+  return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
+  .then(() => {
+    logger.all('watch_api_call_successful_retry');
+
+    // switch to normal reporting
+    programLicensingDataUpdate(schedule, EACH_DAY)
+  })
+  .catch(error => {
+    retryCounts += 1;
+
+    // log the error locally, as this is a retry
+    return logger.logDeprecatedWidgetAPICallError(error, false);
+  });
+}
+
+function stop() {
+  if (timerId) {
+    clearInterval(timerId);
+
+    timerId = null;
+    retryCounts = 0;
+  }
+}
+
+module.exports = {ensureLicensingLoopIsRunning, stop};

--- a/src/deprecated_widget_api_iterations.js
+++ b/src/deprecated_widget_api_iterations.js
@@ -4,7 +4,6 @@
 // This will disappear as soon as Apps Display Licensing is available so code was copied from iterations.js with no special effort to refactor common functionality.
 
 const logger = require("./logger");
-const persistence = require("./persistence");
 const subscriptions = require("./subscriptions");
 
 const MINUTES = 60 * 1000;
@@ -19,7 +18,6 @@ function ensureLicensingLoopIsRunning(schedule = setInterval) {
   if (!timerId) {
     return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
     .then(() => programLicensingDataUpdate(schedule, EACH_DAY))
-    .then(persistence.saveAndReport)
     .catch(error =>
       logger.logDeprecatedWidgetAPICallError(error, true)
       .then(() => programLicensingDataLoadingRetries(schedule))
@@ -34,7 +32,6 @@ function programLicensingDataUpdate(schedule, interval) {
 
   timerId = schedule(() => {
     return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
-    .then(persistence.saveAndReport)
     .catch(logger.logDeprecatedWidgetAPICallError);
   }, interval);
 }
@@ -60,7 +57,6 @@ function retryLicensingDataLoad(schedule) {
     // switch to normal reporting
     programLicensingDataUpdate(schedule, EACH_DAY)
   })
-  .then(persistence.saveAndReport)
   .catch(error => {
     retryCounts += 1;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable default-case */
 
-const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 const config = require("./config");
 const logger = require("./logger");
 const subscriptions = require("./subscriptions");
@@ -9,7 +9,7 @@ const watch = require("./watch");
 const displayConfigBucket = "risevision-display-notifications";
 
 function run(schedule = setInterval) {
-  common.receiveMessages(config.moduleName).then(receiver => {
+  messaging.receiveMessages(config.moduleName).then(receiver => {
     receiver.on("message", message => {
       switch (message.topic.toUpperCase()) {
         case "CLIENT-LIST":
@@ -27,7 +27,7 @@ function run(schedule = setInterval) {
       }
     });
 
-    common.getClientList(config.moduleName);
+    messaging.getClientList(config.moduleName);
 
     return logger.all("started");
   })

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ const displayConfigBucket = "risevision-display-notifications";
 
 function startSubscriptionApiRequestsIfCompanyIdIsAvailable(companyId, licensing, schedule) {
   if (companyId) {
-
     return iterations.configureAndStart(companyId, licensing, schedule);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,63 @@
-/* eslint-disable default-case */
+/* eslint-disable default-case, function-paren-newline, no-unused-expressions, no-unused-vars */
 
 const messaging = require("common-display-module/messaging");
 const config = require("./config");
+const iterations = require("./iterations");
 const logger = require("./logger");
+const persistence = require("./persistence");
 const subscriptions = require("./subscriptions");
 const watch = require("./watch");
 
 const displayConfigBucket = "risevision-display-notifications";
 
+function startSubscriptionApiRequestsIfCompanyIdIsAvailable(companyId, licensing, schedule) {
+  if (companyId) {
+
+    return iterations.configureAndStart(companyId, licensing, schedule);
+  }
+
+  return Promise.resolve();
+}
+
+function configureMessagingHandlers(receiver, schedule) {
+  receiver.on("message", message => {
+    switch (message.topic.toUpperCase()) {
+      case "CLIENT-LIST":
+        return watch.startWatchIfLocalStorageModuleIsAvailable(message);
+      case "LICENSING-REQUEST":
+        return subscriptions.broadcastSubscriptionData();
+      case "FILE-UPDATE":
+        if (!message.filePath || !message.filePath.startsWith(displayConfigBucket)) {
+          return;
+        }
+
+        if (message.filePath.endsWith("/content.json")) {
+          return watch.receiveContentFile(message, schedule);
+        }
+    }
+  });
+
+  messaging.getClientList(config.moduleName);
+
+  return logger.all("started");
+}
+
 function run(schedule = setInterval) {
-  messaging.receiveMessages(config.moduleName).then(receiver => {
-    receiver.on("message", message => {
-      switch (message.topic.toUpperCase()) {
-        case "CLIENT-LIST":
-          return watch.startWatchIfLocalStorageModuleIsAvailable(message);
-        case "LICENSING-REQUEST":
-          return subscriptions.broadcastSubscriptionData();
-        case "FILE-UPDATE":
-          if (!message.filePath || !message.filePath.startsWith(displayConfigBucket)) {
-            return;
-          }
+  return persistence.retrieve()
+  .then(data =>{
+    const {companyId, licensing} = data;
 
-          if (message.filePath.endsWith("/content.json")) {
-            return watch.receiveContentFile(message, schedule);
-          }
-      }
-    });
-
-    messaging.getClientList(config.moduleName);
-
-    return logger.all("started");
+    messaging.receiveMessages(config.moduleName).then(receiver =>
+      startSubscriptionApiRequestsIfCompanyIdIsAvailable(companyId, licensing, schedule)
+      .then(() => configureMessagingHandlers(receiver, schedule))
+      .catch(error =>
+        logger.file(error.stack, 'Unexpected error while configuring messaging handlers')
+      )
+    );
   })
-  .catch(error => logger.file(error.stack, 'Could not connect'));
+  .catch(error =>
+    logger.file(error.stack, 'Unexpected error while starting the module')
+  );
 }
 
 if (process.env.NODE_ENV !== "test") {

--- a/src/iterations.js
+++ b/src/iterations.js
@@ -2,6 +2,7 @@
 
 // Iteration loop, separated to facilitate integration tests
 
+const config = require("./config");
 const logger = require("./logger");
 const subscriptions = require("./subscriptions");
 
@@ -24,6 +25,19 @@ function ensureLicensingLoopIsRunning(schedule = setInterval) {
   }
 
   return Promise.resolve();
+}
+
+function configureAndStart(companyId, initialLicensingData, schedule) {
+  logger.file(`Setting company id as ${companyId}`);
+  config.setCompanyId(companyId);
+
+  if (initialLicensingData && Object.keys(initialLicensingData).length > 0) {
+    subscriptions.init(initialLicensingData);
+
+    subscriptions.broadcastSubscriptionData();
+  }
+
+  return module.exports.ensureLicensingLoopIsRunning(schedule);
 }
 
 function programLicensingDataUpdate(schedule, interval) {
@@ -73,4 +87,4 @@ function stop() {
   }
 }
 
-module.exports = {ensureLicensingLoopIsRunning, stop};
+module.exports = {configureAndStart, ensureLicensingLoopIsRunning, stop};

--- a/src/iterations.js
+++ b/src/iterations.js
@@ -16,7 +16,7 @@ let retryCounts = 0;
 
 function ensureLicensingLoopIsRunning(schedule = setInterval) {
   if (!timerId) {
-    return subscriptions.loadDataAndBroadcast()
+    return subscriptions.loadSubscriptionApiDataAndBroadcast()
     .then(() => programLicensingDataUpdate(schedule, EACH_DAY))
     .catch(error =>
       logger.logSubscriptionAPICallError(error, true)
@@ -44,7 +44,7 @@ function programLicensingDataUpdate(schedule, interval) {
   stop();
 
   timerId = schedule(() => {
-    return subscriptions.loadDataAndBroadcast()
+    return subscriptions.loadSubscriptionApiDataAndBroadcast()
     .catch(logger.logSubscriptionAPICallError);
   }, interval);
 }
@@ -63,7 +63,7 @@ function programLicensingDataLoadingRetries(schedule) {
 }
 
 function retryLicensingDataLoad(schedule) {
-  return subscriptions.loadDataAndBroadcast()
+  return subscriptions.loadSubscriptionApiDataAndBroadcast()
   .then(() => {
     logger.all('api_call_successful_retry');
 

--- a/src/iterations.js
+++ b/src/iterations.js
@@ -22,6 +22,8 @@ function ensureLicensingLoopIsRunning(schedule = setInterval) {
       .then(() => programLicensingDataLoadingRetries(schedule))
     );
   }
+
+  return Promise.resolve();
 }
 
 function programLicensingDataUpdate(schedule, interval) {

--- a/src/iterations.js
+++ b/src/iterations.js
@@ -4,7 +4,6 @@
 
 const config = require("./config");
 const logger = require("./logger");
-const persistence = require("./persistence");
 const subscriptions = require("./subscriptions");
 
 const MINUTES = 60 * 1000;
@@ -19,7 +18,6 @@ function ensureLicensingLoopIsRunning(schedule = setInterval) {
   if (!timerId) {
     return subscriptions.loadSubscriptionApiDataAndBroadcast()
     .then(() => programLicensingDataUpdate(schedule, EACH_DAY))
-    .then(persistence.saveAndReport)
     .catch(error =>
       logger.logSubscriptionAPICallError(error, true)
       .then(() => programLicensingDataLoadingRetries(schedule))
@@ -47,7 +45,6 @@ function programLicensingDataUpdate(schedule, interval) {
 
   timerId = schedule(() => {
     return subscriptions.loadSubscriptionApiDataAndBroadcast()
-    .then(persistence.saveAndReport)
     .catch(logger.logSubscriptionAPICallError);
   }, interval);
 }
@@ -73,7 +70,6 @@ function retryLicensingDataLoad(schedule) {
     // switch to normal reporting
     programLicensingDataUpdate(schedule, EACH_DAY)
   })
-  .then(persistence.saveAndReport)
   .catch(error => {
     retryCounts += 1;
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -39,7 +39,7 @@ function logSubscriptionAPICallError(err, remote = true) {
   const url = getSubscriptionStatusApiUrl();
   const userFriendlyMessage = `Subscription Status API Call failed: ${url}`;
 
-  const call = remote ? error : module.exports.file;
+  const call = remote ? module.exports.error : module.exports.file;
 
   return call(detail, userFriendlyMessage);
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -44,11 +44,22 @@ function logSubscriptionAPICallError(err, remote = true) {
   return call(detail, userFriendlyMessage);
 }
 
+// Will disappear when Apps Display Licensing is available.
+function logDeprecatedWidgetAPICallError(err, remote = true) {
+  const detail = err.stack;
+  const userFriendlyMessage = 'Deprecated Widget Status API Call failed';
+
+  const call = remote ? module.exports.error : module.exports.file;
+
+  return call(detail, userFriendlyMessage);
+}
+
 module.exports = {
   file: logger.file,
   debug: logger.debug,
   error,
   external,
   all,
-  logSubscriptionAPICallError
+  logSubscriptionAPICallError,
+  logDeprecatedWidgetAPICallError
 };

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -2,13 +2,11 @@ const platform = require("rise-common-electron/platform");
 
 const config = require("./config");
 const logger = require("./logger");
-const subscriptions = require("./subscriptions");
 
 const EMPTY_CONTENTS = {companyId: null, licensing: {}};
 
-function save() {
+function save(licensing) {
   const companyId = config.getCompanyId();
-  const licensing = subscriptions.getSubscriptionData();
 
   const data = {companyId, licensing};
   const text = JSON.stringify(data);
@@ -18,8 +16,8 @@ function save() {
   return platform.writeTextFile(path, text);
 }
 
-function saveAndReport() {
-  return module.exports.save()
+function saveAndReport(licensing) {
+  return module.exports.save(licensing)
   .catch(error => {
     const path = config.getCachePath();
 

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -18,6 +18,15 @@ function save() {
   return platform.writeTextFile(path, text);
 }
 
+function saveAndReport() {
+  return module.exports.save()
+  .catch(() => {
+    // const path = config.getCachePath();
+
+    // return logger.error(error.stack, `File write error: ${path}`);
+  })
+}
+
 function retrieve() {
   const path = config.getCachePath();
 
@@ -43,4 +52,4 @@ function retrieve() {
   return Promise.resolve(EMPTY_CONTENTS);
 }
 
-module.exports = {retrieve, save};
+module.exports = {retrieve, save, saveAndReport};

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,0 +1,18 @@
+const platform = require("rise-common-electron/platform");
+
+const config = require("./config");
+const subscriptions = require("./subscriptions");
+
+function save() {
+  const companyId = config.getCompanyId();
+  const licensing = subscriptions.getSubscriptionData();
+
+  const data = {companyId, licensing};
+  const text = JSON.stringify(data);
+
+  const path = config.getCachePath();
+
+  return platform.writeTextFile(path, text);
+}
+
+module.exports = {save};

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -20,10 +20,10 @@ function save() {
 
 function saveAndReport() {
   return module.exports.save()
-  .catch(() => {
-    // const path = config.getCachePath();
+  .catch(error => {
+    const path = config.getCachePath();
 
-    // return logger.error(error.stack, `File write error: ${path}`);
+    return logger.error(error.stack, `File write error: ${path}`);
   })
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -6,16 +6,20 @@ const config = require("./config");
 // See https://developer.risevision.com/documentation/store-api/subscription-status/sub-status-api
 const ACTIVE_STATUS = ["Free", "On Trial", "Subscribed"];
 
-function fetchSubscriptionStatus() {
-  const url = config.getSubscriptionStatusApiUrl();
-
+function fetchJSON(url) {
   const agents = common.getProxyAgents();
   const options = {json: true, agent: agents.httpsAgent};
 
   return got(url, options);
 }
 
-function getSubscriptionStatusTable() {
+function fetchSubscriptionStatus() {
+  const url = config.getSubscriptionStatusApiUrl();
+
+  return fetchJSON(url);
+}
+
+function getSubscriptionStatusUpdates() {
   return module.exports.fetchSubscriptionStatus()
   .then(response => {
     const timestamp = Date.now();
@@ -31,4 +35,17 @@ function getSubscriptionStatusTable() {
   });
 }
 
-module.exports = {fetchSubscriptionStatus, getSubscriptionStatusTable};
+function fetchRisePlayerProfessionalAuthorization() {
+  return common.getDisplayId()
+  .then(displayId => {
+    const url = config.getRisePlayerProfessionalAuthorizationApiUrl(displayId);
+
+    return fetchJSON(url);
+  })
+}
+
+module.exports = {
+  fetchSubscriptionStatus,
+  fetchRisePlayerProfessionalAuthorization,
+  getSubscriptionStatusUpdates
+};

--- a/src/store.js
+++ b/src/store.js
@@ -44,8 +44,14 @@ function fetchRisePlayerProfessionalAuthorization() {
   })
 }
 
+function getRisePlayerProfessionalAuthorization() {
+  return module.exports.fetchRisePlayerProfessionalAuthorization()
+  .then(response => response.body.authorized);
+}
+
 module.exports = {
   fetchSubscriptionStatus,
   fetchRisePlayerProfessionalAuthorization,
-  getSubscriptionStatusUpdates
+  getSubscriptionStatusUpdates,
+  getRisePlayerProfessionalAuthorization
 };

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -1,5 +1,5 @@
 /* eslint-disable function-paren-new, function-paren-newline */
-const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 
 const config = require("./config");
 const store = require("./store");
@@ -17,6 +17,10 @@ function isSubscriptionDataChanged(current, updated) {
     );
 }
 
+function getSubscriptionData() {
+  return currentSubscriptionStatusTable;
+}
+
 function broadcastSubscriptionData() {
   const message = {
     from: config.moduleName,
@@ -24,7 +28,7 @@ function broadcastSubscriptionData() {
     subscriptions: currentSubscriptionStatusTable
   };
 
-  common.broadcastMessage(message);
+  messaging.broadcastMessage(message);
 }
 
 function loadDataAndBroadcast() {
@@ -46,4 +50,10 @@ function clear() {
   currentSubscriptionStatusTable = {};
 }
 
-module.exports = {broadcastSubscriptionData, isSubscriptionDataChanged, loadDataAndBroadcast, clear};
+module.exports = {
+  broadcastSubscriptionData,
+  getSubscriptionData,
+  isSubscriptionDataChanged,
+  loadDataAndBroadcast,
+  clear
+};

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -43,7 +43,8 @@ function applyStatusUpdates(updatedStatusTable) {
     Object.assign({}, currentSubscriptionStatusTable, updatedStatusTable);
 
   if (changed) {
-    logger.file(`Subscription data updated: ${currentSubscriptionStatusTable}`);
+    const data = JSON.stringify(currentSubscriptionStatusTable);
+    logger.file(`Subscription data updated: ${data}`);
 
     return broadcastSubscriptionData();
   }

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -7,6 +7,10 @@ const logger = require("./logger");
 
 let currentSubscriptionStatusTable = {};
 
+function init(data) {
+  currentSubscriptionStatusTable = data;
+}
+
 function isSubscriptionDataChanged(current, updated) {
   const currentKeys = Object.keys(current);
   const updatedKeys = Object.keys(updated);
@@ -51,6 +55,7 @@ function clear() {
 }
 
 module.exports = {
+  init,
   broadcastSubscriptionData,
   getSubscriptionData,
   isSubscriptionDataChanged,

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -33,7 +33,7 @@ function broadcastSubscriptionData() {
     subscriptions: currentSubscriptionStatusTable
   };
 
-  messaging.broadcastMessage(message);
+  return messaging.broadcastMessage(message);
 }
 
 function applyStatusUpdates(updatedStatusTable) {
@@ -42,7 +42,11 @@ function applyStatusUpdates(updatedStatusTable) {
   currentSubscriptionStatusTable =
     Object.assign({}, currentSubscriptionStatusTable, updatedStatusTable);
 
-  return changed && broadcastSubscriptionData();
+  if (changed) {
+    logger.file(`Subscription data updated: ${currentSubscriptionStatusTable}`);
+
+    return broadcastSubscriptionData();
+  }
 }
 
 function loadSubscriptionApiDataAndBroadcast() {

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -3,6 +3,7 @@ const messaging = require("common-display-module/messaging");
 const licensing = require("common-display-module/licensing");
 
 const config = require("./config");
+const persistence = require("./persistence");
 const store = require("./store");
 const logger = require("./logger");
 
@@ -42,12 +43,15 @@ function applyStatusUpdates(updatedStatusTable) {
   currentSubscriptionStatusTable =
     Object.assign({}, currentSubscriptionStatusTable, updatedStatusTable);
 
-  if (changed) {
-    const data = JSON.stringify(currentSubscriptionStatusTable);
-    logger.file(`Subscription data updated: ${data}`);
+  return persistence.saveAndReport(currentSubscriptionStatusTable)
+  .then(() => {
+    if (changed) {
+      const data = JSON.stringify(currentSubscriptionStatusTable);
+      logger.file(`Subscription data updated: ${data}`);
 
-    return broadcastSubscriptionData();
-  }
+      return broadcastSubscriptionData();
+    }
+  });
 }
 
 function loadSubscriptionApiDataAndBroadcast() {
@@ -70,7 +74,7 @@ function loadRisePlayerProfessionalAuthorizationAndBroadcast() {
       }
     };
 
-    applyStatusUpdates(data);
+    return applyStatusUpdates(data);
   })
 }
 

--- a/src/watch.js
+++ b/src/watch.js
@@ -16,7 +16,7 @@ function clearMessageAlreadySentFlag() {
 }
 
 function startWatchIfLocalStorageModuleIsAvailable(message) {
-  if (!watchMessageAlreadySent) {
+  if (!watchMessageAlreadySent && !config.getCompanyId()) {
     logger.debug(JSON.stringify(message));
 
     const clients = message.clients;
@@ -51,10 +51,7 @@ function loadCompanyIdFromContent(data, schedule) {
   if (json.content && json.content.schedule && json.content.schedule.companyId) {
     const companyId = json.content.schedule.companyId;
 
-    logger.file(`Setting company id as ${companyId}`);
-    config.setCompanyId(companyId);
-
-    return iterations.ensureLicensingLoopIsRunning(schedule)
+    return iterations.configureAndStart(companyId, null, schedule)
     .then(persistence.save);
   }
 

--- a/src/watch.js
+++ b/src/watch.js
@@ -6,6 +6,7 @@ const config = require("./config");
 const iterations = require("./iterations");
 const logger = require("./logger");
 const persistence = require("./persistence");
+const subscriptions = require("./subscriptions");
 const platform = require("rise-common-electron").platform;
 
 // So we ensure it will only be sent once.
@@ -52,7 +53,7 @@ function loadCompanyIdFromContent(data, schedule) {
     const companyId = json.content.schedule.companyId;
 
     return iterations.configureAndStart(companyId, null, schedule)
-    .then(persistence.save);
+    .then(() => persistence.save(subscriptions.getSubscriptionData()));
   }
 
   return logger.error(`Company id could not be retrieved from content: ${data}`);

--- a/src/watch.js
+++ b/src/watch.js
@@ -22,7 +22,7 @@ function startWatchIfLocalStorageModuleIsAvailable(message) {
     const clients = message.clients;
 
     if (clients.includes("local-storage")) {
-      return sendWatchMessage()
+      return module.exports.sendWatchMessage()
       .then(() => watchMessageAlreadySent = true)
       .catch(error =>
         logger.file(error.stack, 'Error while sending watch message')
@@ -83,5 +83,6 @@ function receiveContentFile(message, schedule = setInterval) {
 module.exports = {
   startWatchIfLocalStorageModuleIsAvailable,
   clearMessageAlreadySentFlag,
-  receiveContentFile
+  receiveContentFile,
+  sendWatchMessage
 };

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -8,6 +8,7 @@ const platform = require("rise-common-electron").platform;
 
 const config = require("../../src/config");
 const iterations = require("../../src/iterations");
+const widget = require("../../src/deprecated_widget_api_iterations");
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
 const persistence = require("../../src/persistence");
@@ -120,6 +121,7 @@ describe("Licensing - Integration", ()=>
     simple.mock(persistence, "save").resolveWith(true);
     simple.mock(platform, "fileExists").returnWith(true);
     simple.mock(Date, "now").returnWith(100);
+    simple.mock(widget, "ensureLicensingLoopIsRunning").resolveWith(true);
 
     simple.mock(platform, "readTextFile").callFn(path => {
       return Promise.resolve(

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-/* eslint-disable max-statements, no-magic-numbers, function-paren-newline */
+/* eslint-disable max-statements, no-magic-numbers, function-paren-newline, space-infix-ops */
 const assert = require("assert");
 const common = require("common-display-module");
 const messaging = require("common-display-module/messaging");
@@ -116,10 +116,16 @@ describe("Licensing - Integration", ()=>
     simple.mock(messaging, "getClientList").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
     simple.mock(common, "getModuleVersion").returnWith("1.1");
+    simple.mock(common, "getInstallDir").returnWith("/home/rise/rvplayer");
     simple.mock(persistence, "save").resolveWith(true);
     simple.mock(platform, "fileExists").returnWith(true);
-    simple.mock(platform, "readTextFile").resolveWith(content);
     simple.mock(Date, "now").returnWith(100);
+
+    simple.mock(platform, "readTextFile").callFn(path => {
+      return Promise.resolve(
+        path.endsWith('/licensing-cache.json')? '{}' : content
+      );
+    });
 
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
@@ -194,7 +200,7 @@ describe("Licensing - Integration", ()=>
     licensing.run((action, interval) => {
       assert.equal(interval, ONE_DAY);
 
-      assert(messaging.broadcastMessage.callCount, 1);
+      assert.equal(messaging.broadcastMessage.callCount, 1);
 
       {
         const event = messaging.broadcastMessage.lastCall.args[0];
@@ -217,7 +223,7 @@ describe("Licensing - Integration", ()=>
       }
 
       action().then(() => {
-        assert(messaging.broadcastMessage.callCount, 2);
+        assert.equal(messaging.broadcastMessage.callCount, 2);
 
         const event = messaging.broadcastMessage.lastCall.args[0];
 
@@ -241,13 +247,13 @@ describe("Licensing - Integration", ()=>
       })
       .then(() => {
         // no more broadcasts
-        assert(messaging.broadcastMessage.callCount, 2);
+        assert.equal(messaging.broadcastMessage.callCount, 2);
 
         return eventHandler({topic: "licensing-request"});
       })
       .then(() => {
         // forced broadcast, same event as current.
-        assert(messaging.broadcastMessage.callCount, 3);
+        assert.equal(messaging.broadcastMessage.callCount, 3);
 
         const event = messaging.broadcastMessage.lastCall.args[0];
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -8,7 +8,7 @@ const platform = require("rise-common-electron").platform;
 
 const config = require("../../src/config");
 const iterations = require("../../src/iterations");
-const widget = require("../../src/deprecated_widget_api_iterations");
+const deprecatedIterations = require("../../src/deprecated_widget_api_iterations");
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
 const persistence = require("../../src/persistence");
@@ -121,7 +121,8 @@ describe("Licensing - Integration", ()=>
     simple.mock(persistence, "save").resolveWith(true);
     simple.mock(platform, "fileExists").returnWith(true);
     simple.mock(Date, "now").returnWith(100);
-    simple.mock(widget, "ensureLicensingLoopIsRunning").resolveWith(true);
+    simple.mock(deprecatedIterations, "ensureLicensingLoopIsRunning").resolveWith(true);
+    simple.mock(watch, "sendWatchMessage").resolveWith(true);
 
     simple.mock(platform, "readTextFile").callFn(path => {
       return Promise.resolve(
@@ -141,6 +142,7 @@ describe("Licensing - Integration", ()=>
     simple.restore();
     config.setCompanyId(null);
     iterations.stop();
+    deprecatedIterations.stop();
     subscriptions.clear();
     watch.clearMessageAlreadySentFlag();
   });

--- a/test/integration/persistence.js
+++ b/test/integration/persistence.js
@@ -8,6 +8,7 @@ const platform = require("rise-common-electron").platform;
 
 const config = require("../../src/config");
 const iterations = require("../../src/iterations");
+const widget = require("../../src/deprecated_widget_api_iterations");
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
 const persistence = require("../../src/persistence");
@@ -46,6 +47,7 @@ describe("Persistence - Integration", ()=>
     simple.mock(persistence, "save").resolveWith(true);
     simple.mock(platform, "fileExists").returnWith(true);
     simple.mock(Date, "now").returnWith(200);
+    simple.mock(widget, "ensureLicensingLoopIsRunning").resolveWith(true);
 
     simple.mock(platform, "readTextFile").resolveWith(content);
 

--- a/test/integration/persistence.js
+++ b/test/integration/persistence.js
@@ -1,0 +1,179 @@
+/* eslint-env mocha */
+/* eslint-disable max-statements, no-magic-numbers, function-paren-newline, space-infix-ops */
+const assert = require("assert");
+const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
+const simple = require("simple-mock");
+const platform = require("rise-common-electron").platform;
+
+const config = require("../../src/config");
+const iterations = require("../../src/iterations");
+const licensing = require("../../src/index");
+const logger = require("../../src/logger");
+const persistence = require("../../src/persistence");
+const store = require("../../src/store");
+const subscriptions = require("../../src/subscriptions");
+const watch = require("../../src/watch");
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+const content = `
+  {
+    "companyId": 1111,
+    "licensing": {
+      "c4b368be86245bf9501baaa6e0b00df9719869fd": {
+        "active": true, "timestamp": 100
+      },
+      "b0cba08a4baa0c62b8cdc621b6f6a124f89a03db": {
+        "active": false, "timestamp": 100
+      }
+    }
+  }
+`;
+
+describe("Persistence - Integration", ()=>
+{
+
+  beforeEach(() =>
+  {
+    const settings = {displayid: "DIS123"};
+
+    simple.mock(messaging, "broadcastMessage").returnWith();
+    simple.mock(messaging, "getClientList").returnWith();
+    simple.mock(common, "getDisplaySettings").resolveWith(settings);
+    simple.mock(common, "getModuleVersion").returnWith("1.1");
+    simple.mock(common, "getInstallDir").returnWith("/home/rise/rvplayer");
+    simple.mock(persistence, "save").resolveWith(true);
+    simple.mock(platform, "fileExists").returnWith(true);
+    simple.mock(Date, "now").returnWith(200);
+
+    simple.mock(platform, "readTextFile").resolveWith(content);
+
+    simple.mock(logger, "file").returnWith();
+    simple.mock(logger, "all").returnWith();
+    simple.mock(logger, "error").callFn((stack, error) => {
+      console.error(error);
+      console.error(JSON.stringify(stack));
+    });
+  });
+
+  afterEach(() => {
+    simple.restore();
+    config.setCompanyId(null);
+    iterations.stop();
+    subscriptions.clear();
+    watch.clearMessageAlreadySentFlag();
+  });
+
+  it("should start iterations and broadcast licensing events based on cache file contents", done => {
+    let eventHandler = null;
+
+    function Receiver() {
+      this.on = (type, handler) => {
+        eventHandler = handler;
+      }
+    }
+
+    simple.mock(store, "fetchSubscriptionStatus").resolveWith({
+      body: [
+        {
+          pc: 'c4b368be86245bf9501baaa6e0b00df9719869fd',
+          status: 'Subscribed',
+          expiry: null,
+          trialPeriod: 30
+        },
+        {
+          pc: 'b0cba08a4baa0c62b8cdc621b6f6a124f89a03db',
+          status: 'Subscribed',
+          expiry: null,
+          trialPeriod: 30
+        }
+      ]
+    });
+
+    simple.mock(messaging, "receiveMessages").resolveWith(new Receiver());
+
+    licensing.run((action, interval) => {
+      assert.equal(interval, ONE_DAY);
+
+      assert(messaging.broadcastMessage.callCount, 2);
+
+      {
+        const event = messaging.broadcastMessage.calls[0].args[0];
+
+        // I sent the event
+        assert.equal(event.from, "licensing");
+        // it's a log event
+        assert.equal(event.topic, "licensing-update");
+
+        assert(event.subscriptions);
+
+        const rpp = event.subscriptions.c4b368be86245bf9501baaa6e0b00df9719869fd;
+        assert(rpp);
+        assert(rpp.active);
+
+        const storage = event.subscriptions.b0cba08a4baa0c62b8cdc621b6f6a124f89a03db;
+        assert(storage);
+        // cache file marks it as not active
+        assert(!storage.active);
+      }
+
+      {
+        const event = messaging.broadcastMessage.calls[1].args[0];
+
+        // I sent the event
+        assert.equal(event.from, "licensing");
+        // it's a log event
+        assert.equal(event.topic, "licensing-update");
+
+        assert(event.subscriptions);
+
+        const rpp = event.subscriptions.c4b368be86245bf9501baaa6e0b00df9719869fd;
+        assert(rpp);
+        assert(rpp.active);
+
+        const storage = event.subscriptions.b0cba08a4baa0c62b8cdc621b6f6a124f89a03db;
+        assert(storage);
+        // API call says it's active
+        assert(storage.active);
+      }
+
+      action().then(() => {
+        // no more broadcasts
+        assert(messaging.broadcastMessage.callCount, 2);
+
+        return eventHandler({topic: "licensing-request"});
+      })
+      .then(() => {
+        // forced broadcast, same event as current.
+        assert(messaging.broadcastMessage.callCount, 3);
+
+        const event = messaging.broadcastMessage.lastCall.args[0];
+
+        // I sent the event
+        assert.equal(event.from, "licensing");
+        // it's a log event
+        assert.equal(event.topic, "licensing-update");
+
+        assert(event.subscriptions);
+
+        const rpp = event.subscriptions.c4b368be86245bf9501baaa6e0b00df9719869fd;
+        assert(rpp);
+        assert(rpp.active);
+
+        const storage = event.subscriptions.b0cba08a4baa0c62b8cdc621b6f6a124f89a03db;
+        assert(storage);
+        assert(storage.active);
+
+        done();
+      })
+      .catch(error =>
+      {
+        assert.fail(error)
+
+        done()
+      });
+    });
+  });
+
+});

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -9,6 +9,7 @@ const platform = require("rise-common-electron").platform;
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
 const watch = require("../../src/watch");
+const widget = require("../../src/deprecated_widget_api_iterations");
 
 describe("Watch - Integration", ()=>
 {
@@ -24,6 +25,7 @@ describe("Watch - Integration", ()=>
     simple.mock(platform, "fileExists").returnWith(false);
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
+    simple.mock(widget, "ensureLicensingLoopIsRunning").resolveWith(true);
   });
 
   afterEach(() => {

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-statements, global-require, no-magic-numbers */
 const assert = require("assert");
 const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 const simple = require("simple-mock");
 
 const licensing = require("../../src/index");
@@ -14,8 +15,8 @@ describe("Watch - Integration", ()=>
   beforeEach(() => {
     const settings = {displayid: "DIS123"};
 
-    simple.mock(common, "broadcastMessage").returnWith();
-    simple.mock(common, "getClientList").returnWith();
+    simple.mock(messaging, "broadcastMessage").returnWith();
+    simple.mock(messaging, "getClientList").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
@@ -34,8 +35,8 @@ describe("Watch - Integration", ()=>
         .then(() =>
         {
           // no clients, getClientList() should have been called, but no WATCH
-          assert.equal(common.getClientList.callCount, 1);
-          assert.equal(common.broadcastMessage.callCount, 0);
+          assert.equal(messaging.getClientList.callCount, 1);
+          assert.equal(messaging.broadcastMessage.callCount, 0);
 
           // other non-local-storage clients
           return handler({
@@ -46,7 +47,7 @@ describe("Watch - Integration", ()=>
         .then(() =>
         {
           // so WATCH message shouldn't have been sent
-          assert.equal(common.broadcastMessage.callCount, 0);
+          assert.equal(messaging.broadcastMessage.callCount, 0);
 
           // now local-storage is present
           return handler({
@@ -57,10 +58,10 @@ describe("Watch - Integration", ()=>
         .then(() =>
         {
           // so WATCH message should have been sent
-          assert.equal(common.broadcastMessage.callCount, 1);
+          assert.equal(messaging.broadcastMessage.callCount, 1);
 
           // this is the request for content.json
-          const event = common.broadcastMessage.lastCall.args[0];
+          const event = messaging.broadcastMessage.lastCall.args[0];
 
           assert(event);
           // check we sent it
@@ -81,7 +82,7 @@ describe("Watch - Integration", ()=>
       }
     }
 
-    simple.mock(common, "receiveMessages").resolveWith(new Receiver());
+    simple.mock(messaging, "receiveMessages").resolveWith(new Receiver());
 
     licensing.run(() => {});
   });

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -6,10 +6,13 @@ const messaging = require("common-display-module/messaging");
 const simple = require("simple-mock");
 const platform = require("rise-common-electron").platform;
 
+const config = require("../../src/config");
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
+const iterations = require("../../src/iterations");
+const subscriptions = require("../../src/subscriptions");
 const watch = require("../../src/watch");
-const widget = require("../../src/deprecated_widget_api_iterations");
+const deprecatedIterations = require("../../src/deprecated_widget_api_iterations");
 
 describe("Watch - Integration", ()=>
 {
@@ -25,12 +28,16 @@ describe("Watch - Integration", ()=>
     simple.mock(platform, "fileExists").returnWith(false);
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
-    simple.mock(widget, "ensureLicensingLoopIsRunning").resolveWith(true);
+    simple.mock(deprecatedIterations, "ensureLicensingLoopIsRunning").resolveWith(true);
   });
 
   afterEach(() => {
     simple.restore()
     watch.clearMessageAlreadySentFlag();
+    config.setCompanyId(null);
+    iterations.stop();
+    deprecatedIterations.stop();
+    subscriptions.clear();
   });
 
   it("should wait for local-storage to be available to send WATCH messages", done => {
@@ -90,7 +97,7 @@ describe("Watch - Integration", ()=>
 
     simple.mock(messaging, "receiveMessages").resolveWith(new Receiver());
 
-    licensing.run(() => {});
+    licensing.run(() => {}, () => {});
   });
 
 });

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 const common = require("common-display-module");
 const messaging = require("common-display-module/messaging");
 const simple = require("simple-mock");
+const platform = require("rise-common-electron").platform;
 
 const licensing = require("../../src/index");
 const logger = require("../../src/logger");
@@ -18,6 +19,9 @@ describe("Watch - Integration", ()=>
     simple.mock(messaging, "broadcastMessage").returnWith();
     simple.mock(messaging, "getClientList").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
+    simple.mock(common, "getModuleVersion").returnWith("1.1");
+    simple.mock(common, "getInstallDir").returnWith("/home/rise/rvplayer");
+    simple.mock(platform, "fileExists").returnWith(false);
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
   });

--- a/test/manual/deprecated_widget_api_request.js
+++ b/test/manual/deprecated_widget_api_request.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-magic-numbers */
+
+const store = require("../../src/store");
+
+store.fetchRisePlayerProfessionalAuthorization()
+.then(request => console.log(request.body))
+.catch(console.error);

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -25,7 +25,7 @@ describe("Config - Unit", ()=>
 
     const url = config.getSubscriptionStatusApiUrl();
 
-    assert.equal(url, 'https://store-dot-rvaserver2.appspot.com/v1/company/123/product/status?pc=c4b368be86245bf9501baaa6e0b00df9719869fd,b0cba08a4baa0c62b8cdc621b6f6a124f89a03db');
+    assert.equal(url, 'https://store-dot-rvaserver2.appspot.com/v1/company/123/product/status?pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db');
   });
 
   it("Build cache path", () => {

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -1,20 +1,37 @@
 /* eslint-env mocha */
 /* eslint-disable max-statements */
 const assert = require("assert");
+const simple = require("simple-mock");
+const common = require("common-display-module");
 
 const config = require("../../src/config");
 
 describe("Config - Unit", ()=>
 {
 
-  afterEach(() => config.setCompanyId(null));
+  beforeEach(()=>
+  {
+    simple.mock(common, "getModuleVersion").returnWith("1.1");
+    simple.mock(common, "getInstallDir").returnWith("/home/rise/rvplayer");
+  });
 
-  it("Construct Subscription API URL", () => {
+  afterEach(() => {
+    simple.restore();
+    config.setCompanyId(null);
+  });
+
+  it("Build Subscription API URL", () => {
     config.setCompanyId('123');
 
     const url = config.getSubscriptionStatusApiUrl();
 
     assert.equal(url, 'https://store-dot-rvaserver2.appspot.com/v1/company/123/product/status?pc=c4b368be86245bf9501baaa6e0b00df9719869fd,b0cba08a4baa0c62b8cdc621b6f6a124f89a03db');
+  });
+
+  it("Build cache path", () => {
+    const path = config.getCachePath();
+
+    assert.equal(path, "/home/rise/rvplayer/modules/licensing/1.1/licensing-cache.json");
   });
 
   it("Fail on creating Subscription API URL if company id is not set", () => {

--- a/test/unit/deprecated_widget_api_iterations.js
+++ b/test/unit/deprecated_widget_api_iterations.js
@@ -5,6 +5,7 @@ const simple = require("simple-mock");
 
 const logger = require("../../src/logger");
 const iterations = require("../../src/deprecated_widget_api_iterations");
+const persistence = require("../../src/persistence");
 const subscriptions = require("../../src/subscriptions");
 
 const FIVE_MINUTES = 5 * 60 * 1000;
@@ -19,6 +20,7 @@ describe("Deprecated Widget API Iterations - Unit", ()=>
     simple.mock(logger, "logDeprecatedWidgetAPICallError").resolveWith({});
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
+    simple.mock(persistence, "save").resolveWith(true);
   });
 
   afterEach(()=> {

--- a/test/unit/deprecated_widget_api_iterations.js
+++ b/test/unit/deprecated_widget_api_iterations.js
@@ -1,0 +1,153 @@
+/* eslint-env mocha */
+/* eslint-disable max-statements, no-magic-numbers, no-inline-comments, line-comment-position */
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const logger = require("../../src/logger");
+const iterations = require("../../src/deprecated_widget_api_iterations");
+const subscriptions = require("../../src/subscriptions");
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+describe("Deprecated Widget API Iterations - Unit", ()=>
+{
+
+  beforeEach(()=>
+  {
+    simple.mock(logger, "logDeprecatedWidgetAPICallError").resolveWith({});
+    simple.mock(logger, "file").returnWith();
+    simple.mock(logger, "all").returnWith();
+  });
+
+  afterEach(()=> {
+    simple.restore()
+    iterations.stop();
+  });
+
+  it("should program updates if service call succeeds", done => {
+    simple.mock(subscriptions, "loadRisePlayerProfessionalAuthorizationAndBroadcast").resolveWith();
+
+    iterations.ensureLicensingLoopIsRunning((action, interval) => {
+      assert.equal(interval, ONE_DAY);
+      assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 1);
+
+      action()
+      .then(() => {
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 2);
+
+        done();
+      });
+    });
+  });
+
+  it("should retry if first service call fails", done => {
+    let loadCounter = 0;
+    let state = 0;
+
+    simple.mock(subscriptions, "loadRisePlayerProfessionalAuthorizationAndBroadcast").callFn(() => {
+      if (loadCounter === 0) {
+        loadCounter += 1;
+
+        return Promise.reject(new Error('failure'));
+      }
+
+      return Promise.resolve();
+    });
+
+    iterations.ensureLicensingLoopIsRunning((action, interval) => {
+      if (state === 0) {
+        state = 1;
+
+        assert.equal(interval, FIVE_MINUTES);
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 1);
+
+        assert(logger.logDeprecatedWidgetAPICallError.called);
+        assert.equal(logger.logDeprecatedWidgetAPICallError.callCount, 1);
+
+        const call = logger.logDeprecatedWidgetAPICallError.lastCall;
+
+        assert(call.args[0]);
+        assert.equal(call.args[1], true); // remote call
+
+        action();
+      } else {
+        assert.equal(interval, ONE_DAY);
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 2);
+
+        // error did not repeat
+        assert.equal(logger.logDeprecatedWidgetAPICallError.callCount, 1);
+
+        done();
+      }
+    });
+  });
+
+  it("should retry until subscription API gives a successful answer", done => {
+    let loadCounter = 0;
+    let state = 0;
+
+    simple.mock(subscriptions, "loadRisePlayerProfessionalAuthorizationAndBroadcast").callFn(() => {
+      // reject the first 25 requests
+      if (loadCounter < 25) {
+        loadCounter += 1;
+
+        return Promise.reject(new Error('failure'));
+      }
+
+      return Promise.resolve();
+    });
+
+    iterations.ensureLicensingLoopIsRunning((action, interval) => {
+      if (state === 0) {
+        state = 1;
+
+        assert.equal(interval, FIVE_MINUTES);
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 1);
+
+        assert(logger.logDeprecatedWidgetAPICallError.called);
+        assert.equal(logger.logDeprecatedWidgetAPICallError.callCount, 1);
+
+        const call = logger.logDeprecatedWidgetAPICallError.lastCall;
+
+        assert(call.args[0]);
+        assert.equal(call.args[1], true); // remote only first call
+
+        // repeat 12 times * 5 minutes === 1 hour
+        [...Array(12).keys()]
+        .reduce(promise => promise.then(action), Promise.resolve());
+      } else if (state === 1) {
+        state = 2;
+
+        assert.equal(interval, ONE_HOUR);
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 12);
+        assert.equal(logger.all.called, false);
+
+        assert(logger.logDeprecatedWidgetAPICallError.called);
+        assert.equal(logger.logDeprecatedWidgetAPICallError.callCount, 12);
+
+        const call = logger.logDeprecatedWidgetAPICallError.lastCall;
+
+        assert(call.args[0]);
+        assert.equal(call.args[1], false); // local call
+
+        // repeat until service answers after 25 failed attempts
+        [...Array(14).keys()]
+        .reduce(promise => promise.then(action), Promise.resolve());
+      } else {
+        // it finally answered !
+        assert.equal(interval, ONE_DAY);
+        assert(subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast.callCount, 25);
+
+        assert.equal(logger.logDeprecatedWidgetAPICallError.callCount, 25);
+
+        assert.equal(logger.all.callCount, 1);
+        assert.equal(logger.all.lastCall.args[0], 'watch_api_call_successful_retry');
+
+        done();
+      }
+    });
+  });
+
+});

--- a/test/unit/iterations.js
+++ b/test/unit/iterations.js
@@ -6,6 +6,7 @@ const simple = require("simple-mock");
 const config = require("../../src/config");
 const logger = require("../../src/logger");
 const iterations = require("../../src/iterations");
+const persistence = require("../../src/persistence");
 const subscriptions = require("../../src/subscriptions");
 
 const FIVE_MINUTES = 5 * 60 * 1000;
@@ -22,6 +23,7 @@ describe("Iterations - Unit", ()=>
     simple.mock(logger, "logSubscriptionAPICallError").resolveWith({});
     simple.mock(logger, "file").returnWith();
     simple.mock(logger, "all").returnWith();
+    simple.mock(persistence, "save").resolveWith(true);
   });
 
   afterEach(()=> {

--- a/test/unit/iterations.js
+++ b/test/unit/iterations.js
@@ -31,15 +31,15 @@ describe("Iterations - Unit", ()=>
   });
 
   it("should program updates if service call succeeds", done => {
-    simple.mock(subscriptions, "loadDataAndBroadcast").resolveWith();
+    simple.mock(subscriptions, "loadSubscriptionApiDataAndBroadcast").resolveWith();
 
     iterations.ensureLicensingLoopIsRunning((action, interval) => {
       assert.equal(interval, ONE_DAY);
-      assert(subscriptions.loadDataAndBroadcast.callCount, 1);
+      assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 1);
 
       action()
       .then(() => {
-        assert(subscriptions.loadDataAndBroadcast.callCount, 2);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 2);
 
         done();
       });
@@ -50,7 +50,7 @@ describe("Iterations - Unit", ()=>
     let loadCounter = 0;
     let state = 0;
 
-    simple.mock(subscriptions, "loadDataAndBroadcast").callFn(() => {
+    simple.mock(subscriptions, "loadSubscriptionApiDataAndBroadcast").callFn(() => {
       if (loadCounter === 0) {
         loadCounter += 1;
 
@@ -65,7 +65,7 @@ describe("Iterations - Unit", ()=>
         state = 1;
 
         assert.equal(interval, FIVE_MINUTES);
-        assert(subscriptions.loadDataAndBroadcast.callCount, 1);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 1);
 
         assert(logger.logSubscriptionAPICallError.called);
         assert.equal(logger.logSubscriptionAPICallError.callCount, 1);
@@ -78,7 +78,7 @@ describe("Iterations - Unit", ()=>
         action();
       } else {
         assert.equal(interval, ONE_DAY);
-        assert(subscriptions.loadDataAndBroadcast.callCount, 2);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 2);
 
         // error did not repeat
         assert.equal(logger.logSubscriptionAPICallError.callCount, 1);
@@ -92,7 +92,7 @@ describe("Iterations - Unit", ()=>
     let loadCounter = 0;
     let state = 0;
 
-    simple.mock(subscriptions, "loadDataAndBroadcast").callFn(() => {
+    simple.mock(subscriptions, "loadSubscriptionApiDataAndBroadcast").callFn(() => {
       // reject the first 25 requests
       if (loadCounter < 25) {
         loadCounter += 1;
@@ -108,7 +108,7 @@ describe("Iterations - Unit", ()=>
         state = 1;
 
         assert.equal(interval, FIVE_MINUTES);
-        assert(subscriptions.loadDataAndBroadcast.callCount, 1);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 1);
 
         assert(logger.logSubscriptionAPICallError.called);
         assert.equal(logger.logSubscriptionAPICallError.callCount, 1);
@@ -125,7 +125,7 @@ describe("Iterations - Unit", ()=>
         state = 2;
 
         assert.equal(interval, ONE_HOUR);
-        assert(subscriptions.loadDataAndBroadcast.callCount, 12);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 12);
         assert.equal(logger.all.called, false);
 
         assert(logger.logSubscriptionAPICallError.called);
@@ -142,7 +142,7 @@ describe("Iterations - Unit", ()=>
       } else {
         // it finally answered !
         assert.equal(interval, ONE_DAY);
-        assert(subscriptions.loadDataAndBroadcast.callCount, 25);
+        assert(subscriptions.loadSubscriptionApiDataAndBroadcast.callCount, 25);
 
         assert.equal(logger.logSubscriptionAPICallError.callCount, 25);
 

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-statements */
 const assert = require("assert");
 const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 const simple = require("simple-mock");
 
 const config = require("../../src/config");
@@ -15,7 +16,7 @@ describe("Logger - Unit", ()=>
     config.setCompanyId('123');
     const settings = {displayid: "DIS123"};
 
-    simple.mock(common, "broadcastMessage").returnWith();
+    simple.mock(messaging, "broadcastMessage").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
     simple.mock(common, "getModuleVersion").returnWith("1.1");
     simple.mock(logger, "file").returnWith();
@@ -29,10 +30,10 @@ describe("Logger - Unit", ()=>
   it("should log messages", () => {
     return logger.all('started')
     .then(() => {
-      assert(common.broadcastMessage.called);
+      assert(messaging.broadcastMessage.called);
 
       // this is the actual event object sent to the logging module
-      const event = common.broadcastMessage.lastCall.args[0];
+      const event = messaging.broadcastMessage.lastCall.args[0];
 
       // I sent the event
       assert.equal(event.from, "licensing");
@@ -58,11 +59,11 @@ describe("Logger - Unit", ()=>
   it("should log Subscription API call error remotely", () => {
     return logger.logSubscriptionAPICallError(Error('failure'))
     .then(() => {
-      assert(common.broadcastMessage.called);
+      assert(messaging.broadcastMessage.called);
       assert(!logger.file.called);
 
       // this is the actual event object sent to the logging module
-      const event = common.broadcastMessage.lastCall.args[0];
+      const event = messaging.broadcastMessage.lastCall.args[0];
 
       // I sent the event
       assert.equal(event.from, "licensing");
@@ -89,7 +90,7 @@ describe("Logger - Unit", ()=>
     // false flag means local logging.
     logger.logSubscriptionAPICallError(Error('failure'), false);
 
-    assert(!common.broadcastMessage.called);
+    assert(!messaging.broadcastMessage.called);
     assert(logger.file.called);
 
     const call = logger.file.lastCall;

--- a/test/unit/persistence.js
+++ b/test/unit/persistence.js
@@ -1,0 +1,84 @@
+/* eslint-env mocha */
+/* eslint-disable max-statements, no-magic-numbers */
+const assert = require("assert");
+const common = require("common-display-module");
+const simple = require("simple-mock");
+const platform = require("rise-common-electron/platform");
+
+const config = require("../../src/config");
+const persistence = require("../../src/persistence");
+const subscriptions = require("../../src/subscriptions");
+
+describe("Persistence - Unit", ()=>
+{
+
+  beforeEach(()=>
+  {
+    simple.mock(platform, "writeTextFile").resolveWith(true);
+    simple.mock(common, "getModuleVersion").returnWith("1.1");
+    simple.mock(common, "getInstallDir").returnWith("/home/rise/rvplayer");
+  });
+
+  afterEach(()=> {
+    simple.restore()
+    config.setCompanyId(null);
+  });
+
+  it("should save licensing data", () => {
+    simple.mock(subscriptions, "getSubscriptionData").returnWith({
+      c4b368be86245bf9501baaa6e0b00df9719869fd: {
+        active: true, timestamp: 100
+      },
+      b0cba08a4baa0c62b8cdc621b6f6a124f89a03db: {
+        active: true, timestamp: 100
+      }
+    });
+
+    config.setCompanyId(1111);
+
+    return persistence.save().then(() => {
+      assert(platform.writeTextFile.called);
+      assert.equal(platform.writeTextFile.callCount, 1);
+
+      const call = platform.writeTextFile.lastCall;
+
+      const path = call.args[0];
+      assert.equal(path, "/home/rise/rvplayer/modules/licensing/1.1/licensing-cache.json");
+
+      const text = call.args[1];
+      assert(text);
+
+      const json = JSON.parse(text)
+      assert.deepEqual(json, {
+        companyId: 1111,
+        licensing: {
+          c4b368be86245bf9501baaa6e0b00df9719869fd: {
+            active: true, timestamp: 100
+          },
+          b0cba08a4baa0c62b8cdc621b6f6a124f89a03db: {
+            active: true, timestamp: 100
+          }
+        }
+      });
+    });
+  });
+
+  it("should save empty licensing data", () => {
+    return persistence.save().then(() => {
+      assert(platform.writeTextFile.called);
+      assert.equal(platform.writeTextFile.callCount, 1);
+
+      const call = platform.writeTextFile.lastCall;
+
+      const path = call.args[0];
+      assert.equal(path, "/home/rise/rvplayer/modules/licensing/1.1/licensing-cache.json");
+
+      const text = call.args[1];
+      assert(text);
+
+      const json = JSON.parse(text)
+      assert.deepEqual(json, {companyId: null, licensing: {}});
+    });
+  });
+
+});

--- a/test/unit/persistence.js
+++ b/test/unit/persistence.js
@@ -37,7 +37,7 @@ describe("Persistence - Unit", ()=>
 
     config.setCompanyId(1111);
 
-    return persistence.save().then(() => {
+    return persistence.save(subscriptions.getSubscriptionData()).then(() => {
       assert(platform.writeTextFile.called);
       assert.equal(platform.writeTextFile.callCount, 1);
 
@@ -65,7 +65,7 @@ describe("Persistence - Unit", ()=>
   });
 
   it("should save empty licensing data", () => {
-    return persistence.save().then(() => {
+    return persistence.save(subscriptions.getSubscriptionData()).then(() => {
       assert(platform.writeTextFile.called);
       assert.equal(platform.writeTextFile.callCount, 1);
 

--- a/test/unit/persistence.js
+++ b/test/unit/persistence.js
@@ -6,6 +6,7 @@ const simple = require("simple-mock");
 const platform = require("rise-common-electron/platform");
 
 const config = require("../../src/config");
+const logger = require("../../src/logger");
 const persistence = require("../../src/persistence");
 const subscriptions = require("../../src/subscriptions");
 
@@ -78,6 +79,65 @@ describe("Persistence - Unit", ()=>
 
       const json = JSON.parse(text)
       assert.deepEqual(json, {companyId: null, licensing: {}});
+    });
+  });
+
+  it("should retrieve licensing data", () => {
+    simple.mock(platform, "fileExists").returnWith(true);
+
+    simple.mock(platform, "readTextFile").resolveWith(`
+      {
+        "companyId": 1111,
+        "licensing": {
+          "c4b368be86245bf9501baaa6e0b00df9719869fd": {
+            "active": true, "timestamp": 100
+          },
+          "b0cba08a4baa0c62b8cdc621b6f6a124f89a03db": {
+            "active": true, "timestamp": 100
+          }
+        }
+      }
+    `);
+
+    return persistence.retrieve().then(data => {
+    assert.deepEqual(data, {
+        companyId: 1111,
+        licensing: {
+          c4b368be86245bf9501baaa6e0b00df9719869fd: {
+            active: true, timestamp: 100
+          },
+          b0cba08a4baa0c62b8cdc621b6f6a124f89a03db: {
+            active: true, timestamp: 100
+          }
+        }
+      });
+    });
+  });
+
+  it("should retrieve empty data if file is corrupted and log error", () => {
+    simple.mock(platform, "fileExists").returnWith(true);
+    simple.mock(logger, "file").returnWith();
+
+    simple.mock(platform, "readTextFile").resolveWith(`
+      {
+        "companyId": 1111,
+        "licensing": {
+          "c4b368be86245bf9501baaa6e0b00df9719869fd": {
+            "active": true, "timestamp": 100
+          },
+          "b0cba08a4baa0c62b8cdc621b6f6a124f89a03db":
+        }
+      }
+    `);
+
+    return persistence.retrieve().then(data => {
+      assert.deepEqual(data, {companyId: null, licensing: {}});
+
+      assert(logger.file.called);
+      assert.equal(logger.file.callCount, 1);
+
+      const message = logger.file.lastCall.args[1];
+      assert(message.startsWith('Illegal JSON content'));
     });
   });
 

--- a/test/unit/store.js
+++ b/test/unit/store.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-statements, no-magic-numbers */
 const assert = require("assert");
 const simple = require("simple-mock");
+const common = require("common-display-module");
 
 const config = require("../../src/config");
 const store = require("../../src/store");
@@ -11,8 +12,12 @@ describe("Store - Unit", ()=>
 
   beforeEach(()=>
   {
+    const settings = {displayid: "DIS123"};
+
     config.setCompanyId("123");
+
     simple.mock(Date, "now").returnWith(100);
+    simple.mock(common, "getDisplaySettings").resolveWith(settings);
   });
 
   afterEach(()=> {
@@ -179,6 +184,34 @@ describe("Store - Unit", ()=>
         }
       })
     })
+  });
+
+  it("should return active RisePlayerProfessional", () => {
+    simple.mock(store, "fetchRisePlayerProfessionalAuthorization").resolveWith({
+      body: {
+        authorized: true,
+        expiry: '2018-01-25T16:47:42.042+0000',
+        signatures: null,
+        error: null
+      }
+    });
+
+    return store.getRisePlayerProfessionalAuthorization()
+    .then(authorized => assert(authorized))
+  });
+
+  it("should return not active RisePlayerProfessional", () => {
+    simple.mock(store, "fetchRisePlayerProfessionalAuthorization").resolveWith({
+      body: {
+        authorized: false,
+        expiry: '2018-01-25T16:47:42.042+0000',
+        signatures: null,
+        error: null
+      }
+    });
+
+    return store.getRisePlayerProfessionalAuthorization()
+    .then(authorized => assert(!authorized))
   });
 
 });

--- a/test/unit/store.js
+++ b/test/unit/store.js
@@ -32,7 +32,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {
@@ -55,7 +55,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {
@@ -78,7 +78,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {
@@ -101,7 +101,7 @@ describe("Store - Unit", ()=>
         ]
       });
 
-      return store.getSubscriptionStatusTable()
+      return store.getSubscriptionStatusUpdates()
       .then(table =>
       {
         assert.deepEqual(table, {
@@ -124,7 +124,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {
@@ -147,7 +147,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {
@@ -170,7 +170,7 @@ describe("Store - Unit", ()=>
       ]
     });
 
-    return store.getSubscriptionStatusTable()
+    return store.getSubscriptionStatusUpdates()
     .then(table =>
     {
       assert.deepEqual(table, {

--- a/test/unit/subscriptions.js
+++ b/test/unit/subscriptions.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 const simple = require("simple-mock");
 const messaging = require("common-display-module/messaging");
 
+const persistence = require("../../src/persistence");
 const store = require("../../src/store");
 const subscriptions = require("../../src/subscriptions");
 
@@ -13,6 +14,7 @@ describe("Subscriptions - Unit", ()=>
   beforeEach(() => {
     simple.mock(messaging, "broadcastMessage").returnWith();
     simple.mock(Date, "now").returnWith(400);
+    simple.mock(persistence, "save").resolveWith(true);
   })
 
   afterEach(() => {
@@ -213,6 +215,7 @@ describe("Subscriptions - Unit", ()=>
     return subscriptions.loadRisePlayerProfessionalAuthorizationAndBroadcast()
     .then(() => {
       assert(messaging.broadcastMessage.called);
+
       assert.equal(messaging.broadcastMessage.callCount, 1);
       assert.deepEqual(messaging.broadcastMessage.lastCall.args[0], {
         from: 'licensing',

--- a/test/unit/subscriptions.js
+++ b/test/unit/subscriptions.js
@@ -2,7 +2,7 @@
 /* eslint-disable max-statements, no-magic-numbers, function-paren-new */
 const assert = require("assert");
 const simple = require("simple-mock");
-const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 
 const store = require("../../src/store");
 const subscriptions = require("../../src/subscriptions");
@@ -11,7 +11,7 @@ describe("Subscriptions - Unit", ()=>
 {
 
   beforeEach(() => {
-    simple.mock(common, "broadcastMessage").returnWith();
+    simple.mock(messaging, "broadcastMessage").returnWith();
   })
 
   afterEach(() => {
@@ -142,9 +142,9 @@ describe("Subscriptions - Unit", ()=>
 
     return subscriptions.loadDataAndBroadcast()
     .then(() => {
-      assert(common.broadcastMessage.called);
-      assert.equal(common.broadcastMessage.callCount, 1);
-      assert.deepEqual(common.broadcastMessage.lastCall.args[0], {
+      assert(messaging.broadcastMessage.called);
+      assert.equal(messaging.broadcastMessage.callCount, 1);
+      assert.deepEqual(messaging.broadcastMessage.lastCall.args[0], {
         from: 'licensing',
         topic: 'licensing-update',
         subscriptions: {
@@ -160,8 +160,8 @@ describe("Subscriptions - Unit", ()=>
       return subscriptions.loadDataAndBroadcast();
     })
     .then(() => {
-      assert.equal(common.broadcastMessage.callCount, 2);
-      assert.deepEqual(common.broadcastMessage.lastCall.args[0], {
+      assert.equal(messaging.broadcastMessage.callCount, 2);
+      assert.deepEqual(messaging.broadcastMessage.lastCall.args[0], {
         from: 'licensing',
         topic: 'licensing-update',
         subscriptions: {
@@ -178,7 +178,7 @@ describe("Subscriptions - Unit", ()=>
     })
     .then(() => {
       // no further change in active flags even if timestamps change, no broadcast then
-      assert.equal(common.broadcastMessage.callCount, 2);
+      assert.equal(messaging.broadcastMessage.callCount, 2);
     })
   });
 

--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -3,11 +3,13 @@
 const assert = require("assert");
 const logger = require("../../src/logger");
 const common = require("common-display-module");
+const messaging = require("common-display-module/messaging");
 const simple = require("simple-mock");
 const platform = require("rise-common-electron").platform;
 
 const config = require("../../src/config");
 const iterations = require("../../src/iterations");
+const persistence = require("../../src/persistence");
 const watch = require("../../src/watch");
 
 const mockContent = `
@@ -103,11 +105,12 @@ describe("Watch - Unit", ()=> {
   beforeEach(()=> {
     const settings = {displayid: "DIS123"};
 
-    simple.mock(common, "broadcastMessage").returnWith();
+    simple.mock(messaging, "broadcastMessage").returnWith();
     simple.mock(logger, "error").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
     simple.mock(platform, "fileExists").returnWith(true);
-    simple.mock(iterations, "ensureLicensingLoopIsRunning").returnWith();
+    simple.mock(iterations, "ensureLicensingLoopIsRunning").resolveWith(true);
+    simple.mock(persistence, "save").resolveWith(true);
   });
 
   afterEach(()=> {
@@ -116,48 +119,36 @@ describe("Watch - Unit", ()=> {
     simple.restore()
   });
 
-  it("should not send WATCH messages if no module is available", done => {
-    watch.startWatchIfLocalStorageModuleIsAvailable({clients: []})
+  it("should not send WATCH messages if no module is available", () => {
+    return watch.startWatchIfLocalStorageModuleIsAvailable({clients: []})
     .then(() => {
       // no clients, so WATCH messages shouldn't have been sent
-      assert(!common.broadcastMessage.called);
-
-      done();
+      assert(!messaging.broadcastMessage.called);
     })
-    .catch(error => {
-      assert.fail(error)
-
-      done()
-    });
   });
 
-  it("should not send WATCH messages if local-storage module is not available", done => {
-    watch.startWatchIfLocalStorageModuleIsAvailable({
+  it("should not send WATCH messages if local-storage module is not available", () => {
+    return watch.startWatchIfLocalStorageModuleIsAvailable({
       clients: ["logging", "system-metrics"]
     })
     .then(() => {
       // so WATCH messages shouldn't have been sent
-      assert(!common.broadcastMessage.called);
-
-      done();
-    })
-    .catch(error => {
-      assert.fail(error)
-
-      done()
+      assert(!messaging.broadcastMessage.called);
     });
   });
 
-  it("should send WATCH messages if local-storage module is available", done => {
-    watch.startWatchIfLocalStorageModuleIsAvailable({
+  it("should send WATCH messages if local-storage module is available", () => {
+    return watch.startWatchIfLocalStorageModuleIsAvailable({
       clients: ["logging", "system-metrics", "local-storage"]
     })
     .then(() => {
       // so WATCH messages should have been sent for both screen-control.txt and content.json files
-      assert(common.broadcastMessage.called);
-      assert.equal(1, common.broadcastMessage.callCount);
+      console.log(1)
+      assert(messaging.broadcastMessage.called);
+      console.log(2)
+      assert.equal(1, messaging.broadcastMessage.callCount);
 
-      const event = common.broadcastMessage.lastCall.args[0];
+      const event = messaging.broadcastMessage.lastCall.args[0];
 
       assert(event);
       // check we sent it
@@ -166,13 +157,6 @@ describe("Watch - Unit", ()=> {
       assert.equal(event.topic, "watch");
       // check the URL of the file.
       assert.equal(event.filePath, "risevision-display-notifications/DIS123/content.json");
-
-      done();
-    })
-    .catch(error => {
-      assert.fail(error)
-
-      done()
     });
   });
 
@@ -186,6 +170,8 @@ describe("Watch - Unit", ()=> {
     })
     .then(() => {
       assert.deepEqual(config.getCompanyId(), '176314ee-6b88-47ed-a354-10659722dc39');
+
+      assert(persistence.save.called);
     });
   });
 
@@ -200,6 +186,8 @@ describe("Watch - Unit", ()=> {
     })
     .then(() => {
       assert(logger.error.lastCall.args[1].startsWith("Could not parse"));
+
+      assert(!persistence.save.called);
     });
   });
 
@@ -214,6 +202,8 @@ describe("Watch - Unit", ()=> {
     })
     .then(() => {
       assert(logger.error.lastCall.args[0].startsWith("Company id could not be retrieved from content"));
+
+      assert(!persistence.save.called);
     });
   });
 });

--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -111,6 +111,7 @@ describe("Watch - Unit", ()=> {
     simple.mock(platform, "fileExists").returnWith(true);
     simple.mock(iterations, "ensureLicensingLoopIsRunning").resolveWith(true);
     simple.mock(persistence, "save").resolveWith(true);
+    simple.mock(persistence, "saveAndReport").resolveWith(true);
   });
 
   afterEach(()=> {

--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -143,9 +143,7 @@ describe("Watch - Unit", ()=> {
     })
     .then(() => {
       // so WATCH messages should have been sent for both screen-control.txt and content.json files
-      console.log(1)
       assert(messaging.broadcastMessage.called);
-      console.log(2)
       assert.equal(1, messaging.broadcastMessage.callCount);
 
       const event = messaging.broadcastMessage.lastCall.args[0];


### PR DESCRIPTION
File persistence now implemented but also:
- changed calls following common-display-module latest refactoring work
- incorporated call to Widget API to obtain Rise Player Professional licensing status based on display id. This code required a new loop, and is marked as deprecated following Alexis comments in today's standup, and will be replaced by Apps Display Licensing as soon as it becomes available.

Manual tests were also applied to ensure both web service calls work as expected, return licensing data, and are combined well by the module before broadcasting, along with checking that BQ and file logging, and file persistence are working well also.