### PR TITLE
Add log when display.json or rpp authorization files are not found

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -99,6 +99,7 @@ function loadRppAuthorization(json, data) {
 
 function receiveJsonFile(message, label, action) {
   if (["DELETED", "NOEXIST"].includes(message.status)) {
+    logger.error(`${label} file not found`);
     return;
   }
 


### PR DESCRIPTION
You can see test logs using this query: 

```
SELECT * FROM `client-side-events.Module_Events.licensing_events`
WHERE _PARTITIONTIME >= "2018-07-16 00:00:00" AND _PARTITIONTIME < "2018-07-20 00:00:00" 
and display_id = '2XQ5932UWGTY'
```